### PR TITLE
Allow attaching FurnitureBuilder to Empty Game Object (Game Manager)

### DIFF
--- a/Assets/Scripts/FurnitureBuilder.cs
+++ b/Assets/Scripts/FurnitureBuilder.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 
 public class FurnitureBuilder : MonoBehaviour
 {
-    public GameObject selectedPrefab; // Assign in Inspector
     private GameObject selectedPiece;
     private Renderer selectedRenderer;
     private Color selectedOriginalColor;
@@ -139,13 +138,13 @@ public class FurnitureBuilder : MonoBehaviour
 
     void AttachPieceToMarker(Transform marker)
     {
-        if (selectedPrefab == null)
+        if (selectedPiece == null)
         {
-            Debug.LogError("Prefab not assigned in the Inspector!");
+            Debug.LogError("No piece selected to attach!");
             return;
         }
 
-        GameObject newPiece = Instantiate(selectedPrefab);
+        GameObject newPiece = Instantiate(selectedPiece);
 
         // Instantiate the effect
         GameObject placingEffect = Instantiate(placingEffectModel);


### PR DESCRIPTION
When applying this changes, please **disable or delete** the FurnitureBuilder and FurnitureRotator scripts that was originally attached to **Table** object and attach them to GameManager as follows:
<img width="473" height="877" alt="Screenshot 2025-09-23 at 12 28 04 AM" src="https://github.com/user-attachments/assets/1ee3be6b-c373-4af5-8b51-516685867617" />
