### PR TITLE
Controller support

### DIFF
--- a/Assets/InteractController.cs
+++ b/Assets/InteractController.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class InteractController : MonoBehaviour
+{
+    [SerializeField] InventoryManager inventoryManager;
+
+    Ray _GetCurrentScreenCenterRay()
+    {
+        return Camera.main.ViewportPointToRay(new Vector3(0.5F, 0.5F, 0));
+    }
+
+    public void OnOpenBox(InputValue inputValue)
+    {
+        if (!inputValue.isPressed) return;
+
+        if (Physics.Raycast(_GetCurrentScreenCenterRay(), out RaycastHit hit))
+        {
+            GameObject clickedObject = hit.collider.gameObject;
+
+
+            if (clickedObject.CompareTag("FurnitureBox"))
+            {
+                inventoryManager.SetUpExamplePicks();
+                Destroy(clickedObject, 1.5f);
+                return;
+            }
+        }
+    }
+}

--- a/Assets/InteractController.cs.meta
+++ b/Assets/InteractController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e1242a204c0ff614aa3cfdf8fb72afba

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -119,11 +119,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &46898618 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7892947364345689007, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
-  m_PrefabInstance: {fileID: 771851985}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &95878772
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1718,14 +1713,18 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 915045923215286086, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
+      propertyPath: gameManager
+      value: 
+      objectReference: {fileID: 1754259335}
+    - target: {fileID: 915045923215286086, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
+      propertyPath: musicManager
+      value: 
+      objectReference: {fileID: 131556298}
     - target: {fileID: 2035189655483381071, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
       propertyPath: gameManager
       value: 
       objectReference: {fileID: 1754259335}
-    - target: {fileID: 4626316127775021849, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 4922683175401022438, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
       propertyPath: gameManager
       value: 
@@ -1734,18 +1733,6 @@ PrefabInstance:
       propertyPath: overheadCamera
       value: 
       objectReference: {fileID: 1987810469}
-    - target: {fileID: 5819412869709112600, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5819412869709112600, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5819412869709112600, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 1.5
-      objectReference: {fileID: 0}
     - target: {fileID: 5819412869709112600, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
       propertyPath: m_LocalPosition.x
       value: 1.44
@@ -1786,28 +1773,26 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5960042815996331039, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
+      propertyPath: uiController
+      value: 
+      objectReference: {fileID: 384480752}
     - target: {fileID: 7892947364345689007, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
       propertyPath: m_Name
       value: Player
       objectReference: {fileID: 0}
-    - target: {fileID: 8263627976236094323, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 8263627976236094323, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
+    - target: {fileID: 8308569983892852485, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
+      propertyPath: gameManager
+      value: 
+      objectReference: {fileID: 1754259335}
+    - target: {fileID: 8308569983892852485, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
+      propertyPath: inventoryManager
+      value: 
+      objectReference: {fileID: 1754259333}
+    m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 7892947364345689007, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2099011559}
-    - targetCorrespondingSourceObject: {fileID: 7892947364345689007, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2099011561}
-    - targetCorrespondingSourceObject: {fileID: 7892947364345689007, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2099011560}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
 --- !u!1 &832575517
 GameObject:
@@ -3492,59 +3477,12 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 493030228222352761, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
   m_PrefabInstance: {fileID: 771851985}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 46898618}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e087ecce43ebbff45a1b360637807d93, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &2099011559
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 46898618}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4afc06c3b4a545f4ba24cee267fc82e3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  furniture: []
-  moveSpeed: 10
-  maxSpeed: 3.5
-  rotationSpeed: 120
-  cam: {fileID: 0}
---- !u!114 &2099011560
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 46898618}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 61b4907891f3841c9a3565338b58e3d9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: '::'
-  gameManager: {fileID: 1754259335}
-  inventoryManager: {fileID: 1754259333}
---- !u!114 &2099011561
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 46898618}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a14ca26ad453c40ff95cee32ddd5b194, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: '::'
-  gameManager: {fileID: 1754259335}
-  placingEffectModel: {fileID: 5478223930336832509, guid: a7732affad522d64b8aa84f2e8c5e581, type: 3}
-  musicManager: {fileID: 131556298}
-  _isRightTriggerPressed: 0
 --- !u!1001 &2144472759
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3981,6 +3919,10 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 0.06
       objectReference: {fileID: 0}
+    - target: {fileID: 6983356753967942536, guid: e764b6e031f15494e961d4e8f9ac9729, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -179.1667
+      objectReference: {fileID: 0}
     - target: {fileID: 7191381021261650522, guid: e764b6e031f15494e961d4e8f9ac9729, type: 3}
       propertyPath: m_Name
       value: Canvas
@@ -4088,6 +4030,10 @@ PrefabInstance:
     - target: {fileID: 8767718481216075120, guid: e764b6e031f15494e961d4e8f9ac9729, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8999030048525529808, guid: e764b6e031f15494e961d4e8f9ac9729, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -100
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -119,6 +119,11 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &46898618 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7892947364345689007, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
+  m_PrefabInstance: {fileID: 771851985}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &95878772
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1777,6 +1782,10 @@ PrefabInstance:
       propertyPath: uiController
       value: 
       objectReference: {fileID: 384480752}
+    - target: {fileID: 5960042815996331039, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
+      propertyPath: myPlayerInput
+      value: 
+      objectReference: {fileID: 2099011567}
     - target: {fileID: 7892947364345689007, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
       propertyPath: m_Name
       value: Player
@@ -1792,7 +1801,10 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 7892947364345689007, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2099011572}
   m_SourcePrefab: {fileID: 100100000, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
 --- !u!1 &832575517
 GameObject:
@@ -3477,12 +3489,36 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 493030228222352761, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
   m_PrefabInstance: {fileID: 771851985}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 46898618}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e087ecce43ebbff45a1b360637807d93, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &2099011567 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7865015448551729769, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
+  m_PrefabInstance: {fileID: 771851985}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 46898618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62899f850307741f2a39c98a8b639597, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2099011572
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 46898618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e1242a204c0ff614aa3cfdf8fb72afba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  inventoryManager: {fileID: 1754259333}
 --- !u!1001 &2144472759
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4033,7 +4069,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8999030048525529808, guid: e764b6e031f15494e961d4e8f9ac9729, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -100
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1802,6 +1802,12 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 7892947364345689007, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
       insertIndex: -1
       addedObject: {fileID: 2099011559}
+    - targetCorrespondingSourceObject: {fileID: 7892947364345689007, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2099011561}
+    - targetCorrespondingSourceObject: {fileID: 7892947364345689007, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2099011560}
   m_SourcePrefab: {fileID: 100100000, guid: 4ce5ab272136fa949a7203f49a3ea584, type: 3}
 --- !u!1 &832575517
 GameObject:
@@ -2895,8 +2901,6 @@ GameObject:
   - component: {fileID: 1754259332}
   - component: {fileID: 1754259333}
   - component: {fileID: 1754259335}
-  - component: {fileID: 1754259337}
-  - component: {fileID: 1754259336}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -3050,35 +3054,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _isBuildingEnabled: 1
   _isPlayerMovementEnabled: 1
---- !u!114 &1754259336
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1754259329}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 61b4907891f3841c9a3565338b58e3d9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: '::'
-  gameManager: {fileID: 1754259335}
-  inventoryManager: {fileID: 1754259333}
---- !u!114 &1754259337
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1754259329}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a14ca26ad453c40ff95cee32ddd5b194, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: '::'
-  gameManager: {fileID: 1754259335}
-  placingEffectModel: {fileID: 5478223930336832509, guid: a7732affad522d64b8aa84f2e8c5e581, type: 3}
-  musicManager: {fileID: 131556298}
 --- !u!4 &1823958036 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3507217874120997472, guid: dac03c8f27a21476a9e8790318f9594a, type: 3}
@@ -3540,6 +3515,36 @@ MonoBehaviour:
   maxSpeed: 3.5
   rotationSpeed: 120
   cam: {fileID: 0}
+--- !u!114 &2099011560
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 46898618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 61b4907891f3841c9a3565338b58e3d9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+  gameManager: {fileID: 1754259335}
+  inventoryManager: {fileID: 1754259333}
+--- !u!114 &2099011561
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 46898618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a14ca26ad453c40ff95cee32ddd5b194, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+  gameManager: {fileID: 1754259335}
+  placingEffectModel: {fileID: 5478223930336832509, guid: a7732affad522d64b8aa84f2e8c5e581, type: 3}
+  musicManager: {fileID: 131556298}
+  _isRightTriggerPressed: 0
 --- !u!1001 &2144472759
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/FurnitureBuilder.cs
+++ b/Assets/Scripts/FurnitureBuilder.cs
@@ -22,60 +22,56 @@ public class FurnitureBuilder : MonoBehaviour
     // Button Press State
     [SerializeField] bool _isRightTriggerPressed = false;
 
-    // Listen for the BuildSelection button to be pressed. Configured from Player Input.StarterAssets.
-    public void OnBuildSelection()
-    {
-        // if (!Gamepad.current.rightTrigger.wasPressedThisFrame) return;
-
-        Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
-        if (!Physics.Raycast(ray, out RaycastHit hit)) return;
-
-        GameObject clicked = hit.collider.gameObject;
-
-        // Ignore markers for selection
-        if (!clicked.CompareTag("Marker"))
-        {
-            if (clicked == selectedPiece)
-                DeselectPiece();
-            else
-                SelectPiece(clicked);
-        }
-    }
-
     void Update()
     {
         if (!gameManager.GetIsBuildingEnabled()) return;
-
-        // HandleSelection();
-        HandleAttachment();
     }
 
+    /*
+    Project a ray forward from the player's viewpoint (a.k.a the screen). This is required for aiming.
+    */
+    Ray _GetCurrentScreenCenterRay()
+    {
+        return Camera.main.ViewportPointToRay(new Vector3(0.5F, 0.5F, 0));
+    }
+
+    /*
+    Listen for the BuildSelection button to be pressed.
+    Thus it should be triggered only when the button is pressed once! 
+    Configured from Player Input.StarterAssets.
+    */
+    public void OnBuildSelection()
+    {
+        if (selectedPiece == null)
+        {
+            HandleSelection();
+        }
+        else
+        {
+            HandleAttachment();
+        }
+    }
 
     void HandleSelection()
     {
-        if (!IsRightClick()) return;
+        // Raycast from center of screen. Previously used ScreenPointToRay for cursor only.
+        if (!Physics.Raycast(_GetCurrentScreenCenterRay(), out RaycastHit hit)) return;
 
-        Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
-        if (!Physics.Raycast(ray, out RaycastHit hit)) return;
-
-        GameObject clicked = hit.collider.gameObject;
+        GameObject targer = hit.collider.gameObject;
 
         // Ignore markers for selection
-        if (!clicked.CompareTag("Marker"))
+        if (!targer.CompareTag("Marker"))
         {
-            if (clicked == selectedPiece)
+            if (targer == selectedPiece)
                 DeselectPiece();
             else
-                SelectPiece(clicked);
+                SelectPiece(targer);
         }
     }
 
     void HandleAttachment()
     {
-        if (!IsRightClick() || selectedPiece == null) return;
-
-        Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
-        if (!Physics.Raycast(ray, out RaycastHit hit)) return;
+        if (!Physics.Raycast(_GetCurrentScreenCenterRay(), out RaycastHit hit)) return;
 
         GameObject clicked = hit.collider.gameObject;
 
@@ -87,17 +83,6 @@ public class FurnitureBuilder : MonoBehaviour
             Destroy(selectedPiece);
             DeselectPiece();
         }
-    }
-
-    bool IsRightClick()
-    {
-#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
-        if (_isRightTriggerPressed)
-                return UnityEngine.InputSystem.Mouse.current != null &&
-                       UnityEngine.InputSystem.Mouse.current.rightButton.wasPressedThisFrame;
-#else
-        return Input.GetMouseButtonDown(1);
-#endif
     }
 
     void SelectPiece(GameObject piece)

--- a/Assets/Scripts/FurnitureBuilder.cs
+++ b/Assets/Scripts/FurnitureBuilder.cs
@@ -29,6 +29,7 @@ public class FurnitureBuilder : MonoBehaviour
 
     /*
     Project a ray forward from the player's viewpoint (a.k.a the screen). This is required for aiming.
+    Example: https://docs.unity3d.com/6000.0/Documentation/ScriptReference/Camera.ViewportPointToRay.html
     */
     Ray _GetCurrentScreenCenterRay()
     {
@@ -40,49 +41,37 @@ public class FurnitureBuilder : MonoBehaviour
     Thus it should be triggered only when the button is pressed once! 
     Configured from Player Input.StarterAssets.
     */
-    public void OnBuildSelection()
+    public void OnBuildSelection(InputValue inputValue)
     {
-        if (selectedPiece == null)
-        {
-            HandleSelection();
-        }
-        else
-        {
-            HandleAttachment();
-        }
-    }
+        if (!inputValue.isPressed) return;
 
-    void HandleSelection()
-    {
-        // Raycast from center of screen. Previously used ScreenPointToRay for cursor only.
-        if (!Physics.Raycast(_GetCurrentScreenCenterRay(), out RaycastHit hit)) return;
-
-        GameObject targer = hit.collider.gameObject;
-
-        // Ignore markers for selection
-        if (!targer.CompareTag("Marker"))
-        {
-            if (targer == selectedPiece)
-                DeselectPiece();
-            else
-                SelectPiece(targer);
-        }
-    }
-
-    void HandleAttachment()
-    {
         if (!Physics.Raycast(_GetCurrentScreenCenterRay(), out RaycastHit hit)) return;
 
         GameObject clicked = hit.collider.gameObject;
 
-        if (clicked.CompareTag("Marker"))
-        {
-            AttachPieceToMarker(clicked.transform);
+        Debug.Log("### clicked: " + clicked.gameObject.name);
 
-            // Destroy the original selected piece
-            Destroy(selectedPiece);
+        if (selectedPiece == null)
+        {
+            SelectPiece(clicked);
+        }
+        else if (selectedPiece != null && clicked == selectedPiece)
+        {
             DeselectPiece();
         }
+        else if (selectedPiece != null && clicked.CompareTag("Marker"))
+        {
+            HandleAttachment(clicked);
+        }
+    }
+
+    void HandleAttachment(GameObject clicked)
+    {
+        AttachPieceToMarker(clicked.transform);
+
+        // Destroy the original selected piece
+        Destroy(selectedPiece);
+        DeselectPiece();
     }
 
     void SelectPiece(GameObject piece)
@@ -109,6 +98,8 @@ public class FurnitureBuilder : MonoBehaviour
 
     void DeselectPiece()
     {
+        Debug.Log("### Build Deselected!");
+
         if (selectedRenderer != null)
             selectedRenderer.material.color = selectedOriginalColor;
 

--- a/Assets/Scripts/FurnitureBuilder.cs
+++ b/Assets/Scripts/FurnitureBuilder.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System.Collections.Generic;
+using UnityEngine.InputSystem;
 
 public class FurnitureBuilder : MonoBehaviour
 {
@@ -18,13 +19,37 @@ public class FurnitureBuilder : MonoBehaviour
     private List<Renderer> highlightedMarkers = new List<Renderer>();
     private Dictionary<Renderer, Color> markerOriginalColors = new Dictionary<Renderer, Color>();
 
+    // Button Press State
+    [SerializeField] bool _isRightTriggerPressed = false;
+
+    // Listen for the BuildSelection button to be pressed. Configured from Player Input.StarterAssets.
+    public void OnBuildSelection()
+    {
+        // if (!Gamepad.current.rightTrigger.wasPressedThisFrame) return;
+
+        Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
+        if (!Physics.Raycast(ray, out RaycastHit hit)) return;
+
+        GameObject clicked = hit.collider.gameObject;
+
+        // Ignore markers for selection
+        if (!clicked.CompareTag("Marker"))
+        {
+            if (clicked == selectedPiece)
+                DeselectPiece();
+            else
+                SelectPiece(clicked);
+        }
+    }
+
     void Update()
     {
         if (!gameManager.GetIsBuildingEnabled()) return;
 
-        HandleSelection();
+        // HandleSelection();
         HandleAttachment();
     }
+
 
     void HandleSelection()
     {
@@ -67,6 +92,7 @@ public class FurnitureBuilder : MonoBehaviour
     bool IsRightClick()
     {
 #if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+        if (_isRightTriggerPressed)
                 return UnityEngine.InputSystem.Mouse.current != null &&
                        UnityEngine.InputSystem.Mouse.current.rightButton.wasPressedThisFrame;
 #else

--- a/Assets/Scripts/FurnitureRotator.cs
+++ b/Assets/Scripts/FurnitureRotator.cs
@@ -12,8 +12,6 @@ public class FurnitureRotator : MonoBehaviour
 
     private GameObject pivot; // Temporary pivot for group rotations
 
-    public InventoryManager inventoryManager;
-
     /*
     Project a ray forward from the player's viewpoint (a.k.a the screen). This is required for aiming.
     Example: https://docs.unity3d.com/6000.0/Documentation/ScriptReference/Camera.ViewportPointToRay.html
@@ -48,13 +46,6 @@ public class FurnitureRotator : MonoBehaviour
 
             if (clickedObject.CompareTag("Environment"))
             {
-                return;
-            }
-
-            if (clickedObject.CompareTag("FurnitureBox"))
-            {
-                inventoryManager.SetUpExamplePicks();
-                Destroy(clickedObject, 1.5f);
                 return;
             }
 

--- a/Assets/Scripts/Player/CustomPlayerController.cs
+++ b/Assets/Scripts/Player/CustomPlayerController.cs
@@ -16,6 +16,8 @@ Requirements:
 public class CustomPlayerController : MonoBehaviour
 {
 
+    [SerializeField] UIController uiController;
+
     // Stuff that controls player
     GameModeController myGameModeController;
     FirstPersonController myFirstPersonController;
@@ -41,6 +43,13 @@ public class CustomPlayerController : MonoBehaviour
     void Update()
     {
         HandleToggleOverheadView();
+    }
+
+    public void OnToggleInventory(InputValue inputValue)
+    {
+        if (!inputValue.isPressed) return;
+
+        uiController.UItab();
     }
 
     private void HandleToggleOverheadView()

--- a/Assets/Scripts/Player/CustomPlayerController.cs
+++ b/Assets/Scripts/Player/CustomPlayerController.cs
@@ -17,6 +17,7 @@ public class CustomPlayerController : MonoBehaviour
 {
 
     [SerializeField] UIController uiController;
+    [SerializeField] PlayerInput myPlayerInput;
 
     // Stuff that controls player
     GameModeController myGameModeController;
@@ -40,11 +41,6 @@ public class CustomPlayerController : MonoBehaviour
         myIsoFurnitureController = GetComponent<IsoFurnitureController>();
     }
 
-    void Update()
-    {
-        HandleToggleOverheadView();
-    }
-
     public void OnToggleInventory(InputValue inputValue)
     {
         if (!inputValue.isPressed) return;
@@ -52,25 +48,25 @@ public class CustomPlayerController : MonoBehaviour
         uiController.UItab();
     }
 
-    private void HandleToggleOverheadView()
+    public void OnToggleOverheadView(InputValue inputValue)
     {
-        if (_input.isOverheadViewEnabled)
-        {
-            if (_isOverheadViewEnabled)
-            {
-                DisableOverheadView();
-                EnablePlayer();
-                myIsoFurnitureController.enabled = false;
-            }
-            else
-            {
-                EnableOverheadView();
-                DisablePlayer();
-                myIsoFurnitureController.enabled = true;
-            }
 
-            // Treats the toggle button as a one time press event. switch to context.isPressed later
-            _input.isOverheadViewEnabled = false;
+        if (!inputValue.isPressed) return;
+
+        if (_isOverheadViewEnabled)
+        {
+            DisableOverheadView();
+            EnablePlayer();
+            myIsoFurnitureController.enabled = false;
+            myPlayerInput.SwitchCurrentActionMap("Player");
+
+        }
+        else
+        {
+            EnableOverheadView();
+            DisablePlayer();
+            myIsoFurnitureController.enabled = true;
+            myPlayerInput.SwitchCurrentActionMap("Isometric");
         }
     }
 
@@ -86,6 +82,7 @@ public class CustomPlayerController : MonoBehaviour
         myGameModeController.ToggleOverheadView();
     }
 
+    // Might not be needed if mapping switch works! 
     private void DisablePlayer()
     {
         myFirstPersonController.enabled = false;

--- a/Assets/Scripts/UIController.cs
+++ b/Assets/Scripts/UIController.cs
@@ -15,7 +15,7 @@ public class UIController : MonoBehaviour
     public List<Image> popSlots;
     public RectTransform UIbar;
     public GameObject popWindow;
-    private bool closed = false;
+    [SerializeField] bool closed = true;
     private bool uiMode = false;
     private bool popOpen = false;
 
@@ -23,7 +23,7 @@ public class UIController : MonoBehaviour
     void Start()
     {
         popWindow.SetActive(false);
-
+        closed = true;
     }
 
     // Update is called once per frame

--- a/Assets/StarterAssets/FirstPersonController/Scripts/FirstPersonController.cs
+++ b/Assets/StarterAssets/FirstPersonController/Scripts/FirstPersonController.cs
@@ -119,7 +119,6 @@ namespace StarterAssets
 			GroundedCheck();
 			if (gameManager.GetIsPlayerMovementEnabled())
 			{
-				Debug.Log("###HERE");
 				Move();
 			}
 

--- a/Assets/StarterAssets/InputSystem/StarterAssets.inputactions
+++ b/Assets/StarterAssets/InputSystem/StarterAssets.inputactions
@@ -58,6 +58,51 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "RotateSelection",
+                    "type": "Button",
+                    "id": "a7c289ca-805c-4274-8262-8f64f699ffa5",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "RotateObjectUp",
+                    "type": "Button",
+                    "id": "2b972c22-db7d-4a01-95ed-ecad73df84c3",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "RotateObjectRight",
+                    "type": "Button",
+                    "id": "f101caf9-0577-4c42-bf1e-d44023558e4d",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "RotateObjectDown",
+                    "type": "Button",
+                    "id": "cc35a4a0-8d35-4b74-babd-295880ca328d",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "RotateObjectLeft",
+                    "type": "Button",
+                    "id": "6fa061c8-4008-468d-ba61-5fb21c196eb4",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -278,6 +323,144 @@
                     "processors": "",
                     "groups": ";Gamepad",
                     "action": "BuildSelection",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "53b93cf7-cd57-42be-926b-7b8b38dd5918",
+                    "path": "<Mouse>/leftButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";KeyboardMouse",
+                    "action": "RotateSelection",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "778cb9ca-b46e-4c47-920b-7ff49e03eecf",
+                    "path": "<Gamepad>/leftTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "RotateSelection",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "00c9c35c-b21d-43d4-b0fd-5f43491479a4",
+                    "path": "<Keyboard>/upArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";KeyboardMouse",
+                    "action": "RotateObjectUp",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "89cb9a52-f759-411e-8a4a-8f1cf62f4841",
+                    "path": "<Gamepad>/dpad/up",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "RotateObjectUp",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "39bb4d00-675f-475f-a228-849c2fa447c0",
+                    "path": "<Keyboard>/rightArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";KeyboardMouse",
+                    "action": "RotateObjectRight",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "8f803dc2-6702-4e8f-8b10-20c6b78bd4c1",
+                    "path": "<Gamepad>/dpad/right",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "RotateObjectRight",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "494a6d8e-8172-494d-b55e-4fee232f07c9",
+                    "path": "<Keyboard>/leftArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";KeyboardMouse",
+                    "action": "RotateObjectLeft",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "ab9b320c-c6a9-4746-9c66-c7b2a85d4321",
+                    "path": "<Gamepad>/dpad/left",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "RotateObjectLeft",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "6a70a798-529f-4b25-a55d-ced85bdd26e5",
+                    "path": "<Keyboard>/downArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";KeyboardMouse",
+                    "action": "RotateObjectDown",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "517625b1-6595-42fc-bbdd-f4298f94b9d9",
+                    "path": "<Gamepad>/dpad/down",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "RotateObjectDown",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
+        },
+        {
+            "name": "Isometric",
+            "id": "15e709c6-e1df-43be-94d2-c94ef8e8bc79",
+            "actions": [
+                {
+                    "name": "New action",
+                    "type": "Button",
+                    "id": "6c62ee73-e803-485f-85de-f9c318f8de7f",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "70586dc1-a04b-4b0f-8b93-d2c0eeaedd58",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "New action",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/StarterAssets/InputSystem/StarterAssets.inputactions
+++ b/Assets/StarterAssets/InputSystem/StarterAssets.inputactions
@@ -42,15 +42,6 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "ToggleOverheadView",
-                    "type": "Button",
-                    "id": "07d5a69b-c13c-4d16-8051-37d4dc1d4c77",
-                    "expectedControlType": "",
-                    "processors": "",
-                    "interactions": "",
-                    "initialStateCheck": false
-                },
-                {
                     "name": "BuildSelection",
                     "type": "Button",
                     "id": "cd4f6829-ad0a-4cff-91ae-9c34f97b5eae",
@@ -108,6 +99,24 @@
                     "name": "ToggleInventory",
                     "type": "Button",
                     "id": "fb383498-a877-4720-af67-2b3b67566955",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ToggleOverheadView",
+                    "type": "Button",
+                    "id": "07d5a69b-c13c-4d16-8051-37d4dc1d4c77",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "OpenBox",
+                    "type": "Button",
+                    "id": "5cdb6d9d-d499-4da3-bc98-fc2993deebf1",
                     "expectedControlType": "",
                     "processors": "",
                     "interactions": "",
@@ -453,6 +462,28 @@
                     "processors": "",
                     "groups": ";Gamepad",
                     "action": "ToggleInventory",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "4ee6f7c0-3c83-4d71-a540-48ea72d5e141",
+                    "path": "<Keyboard>/e",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";KeyboardMouse",
+                    "action": "OpenBox",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "04786270-ccb6-4fb5-8801-a3cfa9aafbb4",
+                    "path": "<Gamepad>/buttonSouth",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "OpenBox",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/StarterAssets/InputSystem/StarterAssets.inputactions
+++ b/Assets/StarterAssets/InputSystem/StarterAssets.inputactions
@@ -49,6 +49,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "BuildSelection",
+                    "type": "Button",
+                    "id": "cd4f6829-ad0a-4cff-91ae-9c34f97b5eae",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -223,7 +232,7 @@
                     "path": "<Gamepad>/leftTrigger",
                     "interactions": "",
                     "processors": "",
-                    "groups": "Gamepad",
+                    "groups": "",
                     "action": "Sprint",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -247,6 +256,17 @@
                     "processors": "",
                     "groups": ";KeyboardMouse",
                     "action": "ToggleOverheadView",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "9e70d288-5118-414e-bfe9-9ac79d44053f",
+                    "path": "<Gamepad>/rightTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "BuildSelection",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/StarterAssets/InputSystem/StarterAssets.inputactions
+++ b/Assets/StarterAssets/InputSystem/StarterAssets.inputactions
@@ -103,6 +103,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "ToggleInventory",
+                    "type": "Button",
+                    "id": "fb383498-a877-4720-af67-2b3b67566955",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -433,6 +442,17 @@
                     "processors": "",
                     "groups": ";Gamepad",
                     "action": "RotateObjectDown",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "01d62117-0944-4989-8626-93c11de69262",
+                    "path": "<Gamepad>/buttonNorth",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "ToggleInventory",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/StarterAssets/InputSystem/StarterAssets.inputactions
+++ b/Assets/StarterAssets/InputSystem/StarterAssets.inputactions
@@ -8,7 +8,7 @@
                 {
                     "name": "Move",
                     "type": "Value",
-                    "id": "6bc1aaf4-b110-4ff7-891e-5b9fe6f32c4d",
+                    "id": "db4eb2d2-30ef-4e34-bdbe-bc9be5bc2b74",
                     "expectedControlType": "Vector2",
                     "processors": "",
                     "interactions": "",
@@ -105,15 +105,6 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "ToggleOverheadView",
-                    "type": "Button",
-                    "id": "07d5a69b-c13c-4d16-8051-37d4dc1d4c77",
-                    "expectedControlType": "",
-                    "processors": "",
-                    "interactions": "",
-                    "initialStateCheck": false
-                },
-                {
                     "name": "OpenBox",
                     "type": "Button",
                     "id": "5cdb6d9d-d499-4da3-bc98-fc2993deebf1",
@@ -121,119 +112,18 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "ToggleOverheadView",
+                    "type": "Button",
+                    "id": "07d5a69b-c13c-4d16-8051-37d4dc1d4c77",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
-                {
-                    "name": "WASD",
-                    "id": "b7594ddb-26c9-4ba2-bd5a-901468929edc",
-                    "path": "2DVector(mode=1)",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "Move",
-                    "isComposite": true,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "up",
-                    "id": "2063a8b5-6a45-43de-851b-65f3d46e7b58",
-                    "path": "<Keyboard>/w",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "KeyboardMouse",
-                    "action": "Move",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "down",
-                    "id": "64e4d037-32e1-4fb9-80e4-fc7330404dfe",
-                    "path": "<Keyboard>/s",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "KeyboardMouse",
-                    "action": "Move",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "left",
-                    "id": "0fce8b11-5eab-4e4e-a741-b732e7b20873",
-                    "path": "<Keyboard>/a",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "KeyboardMouse",
-                    "action": "Move",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "right",
-                    "id": "7bdda0d6-57a8-47c8-8238-8aecf3110e47",
-                    "path": "<Keyboard>/d",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "KeyboardMouse",
-                    "action": "Move",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "up",
-                    "id": "bb94b405-58d3-4998-8535-d705c1218a98",
-                    "path": "<Keyboard>/upArrow",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "KeyboardMouse",
-                    "action": "Move",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "down",
-                    "id": "929d9071-7dd0-4368-9743-6793bb98087e",
-                    "path": "<Keyboard>/downArrow",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "KeyboardMouse",
-                    "action": "Move",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "left",
-                    "id": "28abadba-06ff-4d37-bb70-af2f1e35a3b9",
-                    "path": "<Keyboard>/leftArrow",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "KeyboardMouse",
-                    "action": "Move",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "right",
-                    "id": "45f115b6-9b4f-4ba8-b500-b94c93bf7d7e",
-                    "path": "<Keyboard>/rightArrow",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "KeyboardMouse",
-                    "action": "Move",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "",
-                    "id": "e2f9aa65-db06-4c5b-a2e9-41bc8acb9517",
-                    "path": "<Gamepad>/leftStick",
-                    "interactions": "",
-                    "processors": "StickDeadzone",
-                    "groups": "Gamepad",
-                    "action": "Move",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
                 {
                     "name": "",
                     "id": "ed66cbff-2900-4a62-8896-696503cfcd31",
@@ -319,6 +209,116 @@
                     "processors": "",
                     "groups": ";KeyboardMouse",
                     "action": "ToggleOverheadView",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "WASD",
+                    "id": "90ebbe46-97fb-4598-9200-3224d2b87dad",
+                    "path": "2DVector(mode=1)",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Move",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "cd890fa1-0fed-4476-96fd-d947ff251be3",
+                    "path": "<Keyboard>/w",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardMouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "596194b7-811f-4902-a495-91f2c6d06347",
+                    "path": "<Keyboard>/s",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardMouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "53f8cea1-94bc-4cca-908e-f4db7c542a5e",
+                    "path": "<Keyboard>/a",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardMouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "dc9d4fd2-39b2-4d26-812d-a95f72278c50",
+                    "path": "<Keyboard>/d",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardMouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "up",
+                    "id": "dfca7826-e553-4019-99ab-51dfe45ab1fa",
+                    "path": "<Keyboard>/upArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardMouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "d4f1b95f-bda1-422c-9819-be18c606df9f",
+                    "path": "<Keyboard>/downArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardMouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "dd2a3c5b-8265-493e-9edc-dc461a984c65",
+                    "path": "<Keyboard>/leftArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardMouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "0d32e59b-2002-4a2c-8443-0eab5a249bc4",
+                    "path": "<Keyboard>/rightArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardMouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "c2f9d5ce-ee11-4048-accf-bfb26972426e",
+                    "path": "<Gamepad>/leftStick",
+                    "interactions": "",
+                    "processors": "StickDeadzone",
+                    "groups": "Gamepad",
+                    "action": "Move",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -494,9 +494,27 @@
             "id": "15e709c6-e1df-43be-94d2-c94ef8e8bc79",
             "actions": [
                 {
-                    "name": "New action",
+                    "name": "Move",
+                    "type": "Value",
+                    "id": "504a7d0c-cb66-41db-9f2d-2c6b420eebff",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "Look",
+                    "type": "Value",
+                    "id": "fd9104e3-d740-4aba-92fd-cfca6fda9144",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "ToggleOverheadView",
                     "type": "Button",
-                    "id": "6c62ee73-e803-485f-85de-f9c318f8de7f",
+                    "id": "f4b772cb-fd9c-4492-a1c7-3be08ad9e789",
                     "expectedControlType": "",
                     "processors": "",
                     "interactions": "",
@@ -506,12 +524,155 @@
             "bindings": [
                 {
                     "name": "",
-                    "id": "70586dc1-a04b-4b0f-8b93-d2c0eeaedd58",
-                    "path": "",
+                    "id": "c7c39445-305d-4619-970c-185762d9ab53",
+                    "path": "<Pointer>/delta",
+                    "interactions": "",
+                    "processors": "InvertVector2(invertX=false),ScaleVector2(x=0.05,y=0.05)",
+                    "groups": "KeyboardMouse",
+                    "action": "Look",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "9baf2f08-0cc3-446b-bda4-ec07377de97d",
+                    "path": "<Gamepad>/rightStick",
+                    "interactions": "",
+                    "processors": "InvertVector2(invertX=false),StickDeadzone,ScaleVector2(x=300,y=300)",
+                    "groups": "Gamepad",
+                    "action": "Look",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "4a3aedf9-12a8-41e1-9863-8f607d8612cc",
+                    "path": "<Gamepad>/select",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "ToggleOverheadView",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "667dbb8b-558f-4ca7-b045-f5965a714dc2",
+                    "path": "<Keyboard>/q",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";KeyboardMouse",
+                    "action": "ToggleOverheadView",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "WASD",
+                    "id": "056bf4a5-f09d-47aa-94f5-58a5d680cfec",
+                    "path": "2DVector(mode=1)",
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "New action",
+                    "action": "Move",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "bd162999-a790-4da4-aa76-7c777ac461bb",
+                    "path": "<Keyboard>/w",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardMouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "27c5e138-4518-4836-9640-83f1b4eb0816",
+                    "path": "<Keyboard>/s",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardMouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "32f90d93-69d5-4303-baf3-1f840662df80",
+                    "path": "<Keyboard>/a",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardMouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "db022845-a7c8-4a0d-b5cf-c56fb16c5d66",
+                    "path": "<Keyboard>/d",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardMouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "up",
+                    "id": "46da89c3-05da-4707-8110-2a46fcb69d5e",
+                    "path": "<Keyboard>/upArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardMouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "5998261d-1ad9-4fea-b07e-cd73129ef2a4",
+                    "path": "<Keyboard>/downArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardMouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "06b8b4b0-228d-4630-b3f5-c204cfa7e0b1",
+                    "path": "<Keyboard>/leftArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardMouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "6c7ede69-935b-4d5a-ba9d-447967279027",
+                    "path": "<Keyboard>/rightArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardMouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "3d7b77db-2571-414c-b9f6-5129460b113a",
+                    "path": "<Gamepad>/leftStick",
+                    "interactions": "",
+                    "processors": "StickDeadzone",
+                    "groups": "Gamepad",
+                    "action": "Move",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/StarterAssets/InputSystem/StarterAssets.inputactions
+++ b/Assets/StarterAssets/InputSystem/StarterAssets.inputactions
@@ -261,6 +261,17 @@
                 },
                 {
                     "name": "",
+                    "id": "87644ecb-6768-444e-9b13-fc5c7ca4400a",
+                    "path": "<Mouse>/rightButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";KeyboardMouse",
+                    "action": "BuildSelection",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
                     "id": "9e70d288-5118-414e-bfe9-9ac79d44053f",
                     "path": "<Gamepad>/rightTrigger",
                     "interactions": "",

--- a/Assets/StarterAssets/InputSystem/StarterAssetsInputs.cs
+++ b/Assets/StarterAssets/InputSystem/StarterAssetsInputs.cs
@@ -19,10 +19,6 @@ namespace StarterAssets
 		[Header("Mouse Cursor Settings")]
 		public bool cursorLocked = true;
 		public bool cursorInputForLook = true;
-
-		[Header("Overhead View Settings")]
-		public bool isOverheadViewEnabled = false;
-
 #if ENABLE_INPUT_SYSTEM
 		public void OnMove(InputValue value)
 		{
@@ -45,11 +41,6 @@ namespace StarterAssets
 		public void OnSprint(InputValue value)
 		{
 			SprintInput(value.isPressed);
-		}
-
-		public void OnToggleOverheadView(InputValue value)
-		{
-			SetIsOverheadViewEnabled(value.isPressed);
 		}
 #endif
 
@@ -82,11 +73,6 @@ namespace StarterAssets
 		private void SetCursorState(bool newState)
 		{
 			Cursor.lockState = newState ? CursorLockMode.Locked : CursorLockMode.None;
-		}
-
-		private void SetIsOverheadViewEnabled(bool newState)
-		{
-			isOverheadViewEnabled = newState;
 		}
 	}
 

--- a/Assets/export/PlayerCapsule.prefab
+++ b/Assets/export/PlayerCapsule.prefab
@@ -51,6 +51,9 @@ GameObject:
   - component: {fileID: 4260338377666475930}
   - component: {fileID: 5960042815996331039}
   - component: {fileID: 4922683175401022438}
+  - component: {fileID: 4845527505090840211}
+  - component: {fileID: 915045923215286086}
+  - component: {fileID: 8308569983892852485}
   m_Layer: 8
   m_Name: PlayerCapsule
   m_TagString: Player
@@ -68,7 +71,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.2, y: 0, z: 1.38}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1.5}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3902107423964109246}
@@ -112,6 +115,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 55919ac34a26952479f3fc91f777b2fa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  gameManager: {fileID: 0}
   MoveSpeed: 4
   SprintSpeed: 6
   RotationSpeed: 1
@@ -358,6 +362,53 @@ MonoBehaviour:
   gameManager: {fileID: 0}
   playerCamera: {fileID: 4626316127775021849}
   overheadCamera: {fileID: 0}
+--- !u!114 &4845527505090840211
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7892947364345689007}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4afc06c3b4a545f4ba24cee267fc82e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  furniture: []
+  moveSpeed: 10
+  maxSpeed: 3.5
+  rotationSpeed: 120
+  cam: {fileID: 0}
+--- !u!114 &915045923215286086
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7892947364345689007}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a14ca26ad453c40ff95cee32ddd5b194, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+  gameManager: {fileID: 0}
+  placingEffectModel: {fileID: 5478223930336832509, guid: a7732affad522d64b8aa84f2e8c5e581, type: 3}
+  musicManager: {fileID: 0}
+  _isRightTriggerPressed: 0
+--- !u!114 &8308569983892852485
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7892947364345689007}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 61b4907891f3841c9a3565338b58e3d9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+  gameManager: {fileID: 0}
+  inventoryManager: {fileID: 0}
 --- !u!1 &8869246048571391383
 GameObject:
   m_ObjectHideFlags: 0
@@ -518,9 +569,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 9005220659476430823, guid: 2d3a85ecde41a8246a79669975912b74, type: 3}
-      insertIndex: 2
-      addedObject: {fileID: 8263627976236094323}
-    - targetCorrespondingSourceObject: {fileID: 9005220659476430823, guid: 2d3a85ecde41a8246a79669975912b74, type: 3}
       insertIndex: -1
       addedObject: {fileID: 5551108061883065411}
     - targetCorrespondingSourceObject: {fileID: 9005220659476430823, guid: 2d3a85ecde41a8246a79669975912b74, type: 3}
@@ -532,49 +580,6 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 9005220659476430823, guid: 2d3a85ecde41a8246a79669975912b74, type: 3}
   m_PrefabInstance: {fileID: 4380597792581166334}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &8263627976236094323
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4626316127775021849}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f9dfa5b682dcd46bda6128250e975f58, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Priority:
-    Enabled: 1
-    m_Value: 0
-  OutputChannel: 1
-  StandbyUpdate: 2
-  m_StreamingVersion: 20241001
-  m_LegacyPriority: 0
-  Target:
-    TrackingTarget: {fileID: 0}
-    LookAtTarget: {fileID: 0}
-    CustomLookAtTarget: 0
-  Lens:
-    FieldOfView: 60
-    OrthographicSize: 10
-    NearClipPlane: 0.1
-    FarClipPlane: 5000
-    Dutch: 0
-    ModeOverride: 0
-    PhysicalProperties:
-      GateFit: 2
-      SensorSize: {x: 21.946, y: 16.002}
-      LensShift: {x: 0, y: 0}
-      FocusDistance: 10
-      Iso: 200
-      ShutterSpeed: 0.005
-      Aperture: 16
-      BladeCount: 5
-      Curvature: {x: 2, y: 11}
-      BarrelClipping: 0.25
-      Anamorphism: 0
-  BlendHint: 0
 --- !u!114 &5551108061883065411
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -2,8 +2,13 @@
 %TAG !u! tag:unity3d.com,2011:
 --- !u!78 &1
 TagManager:
-  serializedVersion: 2
-  tags: []
+  serializedVersion: 3
+  tags:
+  - Environment
+  - FurnitureBox
+  - Marker
+  - Furniture
+  - CinemachineTarget
   layers:
   - Default
   - TransparentFX
@@ -50,27 +55,3 @@ TagManager:
   - Light Layer 5
   - Light Layer 6
   - Light Layer 7
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 
-  - 


### PR DESCRIPTION
## Changes:
- Use Viewport raycast from center of screen for aiming instead of cursor position
    - This allows controller and mouse to work since we have the aiming reticle on screen
- 2 separate control maps for: building and isometric view
    - This takes advantage of the New Input System to re-map buttons on the controller on the fly!
    - Source: https://discussions.unity.com/t/how-do-we-switch-action-maps-i-cant-wrap-my-head-around-all-of-these-things/1561571
- Toggle UI off/on

## Missing:
- Can't navigate UI. not sure how to switch context to UI. We probably need highlight effects to indicate selection as well.

## Player Action Mapping:
See controls in GDD = https://docs.google.com/document/d/1cBpWQzLcnmKqUUUGLXTO0BkUbGCmuRrIZTLU-XrPL9I/edit?tab=t.0


## How does it work?
1. Player's root game object has a component called "Player Actions" > "Actions". Double click it to see all event names mapped to a button/stick press.
2. Using the `On____` convention, define event listeners in any script! Example: `OnBuildSelection` in `FurnitureBuilder`
    - Know these are automatically always listening, so we don't need to put it in update
    - For single press, we should have a bool to represent state, but we can skip that assuming players won't press and hold stuff
3. Like said early, there are 2 sets of maps:
    - Player: movement, building etc
    - Isometric: placement mode controlls
This was done so we can toggle controls easily without having to enable/disable scripts.
