### PR TITLE
Properly enable/disable player and isometric scripts when changing modes.

### DIFF
--- a/Assets/Scripts/Player/CustomPlayerController.cs
+++ b/Assets/Scripts/Player/CustomPlayerController.cs
@@ -26,20 +26,19 @@ public class CustomPlayerController : MonoBehaviour
     PlayerAnimationController myPlayerAnimationController;
     IsoFurnitureController myIsoFurnitureController;
 
-    private StarterAssetsInputs _input;
-
     // State Flags
     bool _isIsometricViewEnabled = false;
 
 
     void Start()
     {
-        _input = GetComponent<StarterAssetsInputs>();
-
         myGameModeController = GetComponent<GameModeController>();
         myFirstPersonController = GetComponent<FirstPersonController>();
         myPlayerAnimationController = GetComponent<PlayerAnimationController>();
         myIsoFurnitureController = GetComponent<IsoFurnitureController>();
+
+        // Make sure isometric controller is off first thing. Sometimes we forget to turn it off in editor.
+        myIsoFurnitureController.enabled = false;
     }
 
     public void OnQuitGame()
@@ -64,6 +63,9 @@ public class CustomPlayerController : MonoBehaviour
         {
             _isIsometricViewEnabled = false;
             myIsoFurnitureController.enabled = false;
+
+            SetPlayerScriptsEnabledState(true);
+
             myPlayerInput.SwitchCurrentActionMap("Player");
             playerSFXController.PlayCloseInventorySFX();
             myGameModeController.ShowOriginalView();
@@ -72,9 +74,16 @@ public class CustomPlayerController : MonoBehaviour
         {
             _isIsometricViewEnabled = true;
             myIsoFurnitureController.enabled = true;
+            SetPlayerScriptsEnabledState(false);
             myPlayerInput.SwitchCurrentActionMap("Isometric");
             playerSFXController.PlayOpenInventorySFX();
             myGameModeController.ShowOverheadView();
         }
+    }
+
+    void SetPlayerScriptsEnabledState(bool newState)
+    {
+        myFirstPersonController.enabled = newState;
+        myPlayerAnimationController.enabled = newState;
     }
 }

--- a/Assets/StarterAssets/InputSystem/StarterAssets.inputactions
+++ b/Assets/StarterAssets/InputSystem/StarterAssets.inputactions
@@ -533,7 +533,7 @@
                     "initialStateCheck": true
                 },
                 {
-                    "name": "ToggleOverheadView",
+                    "name": "ToggleIsometricView",
                     "type": "Button",
                     "id": "f4b772cb-fd9c-4492-a1c7-3be08ad9e789",
                     "expectedControlType": "",
@@ -572,18 +572,18 @@
                     "interactions": "",
                     "processors": "",
                     "groups": ";Gamepad",
-                    "action": "ToggleOverheadView",
+                    "action": "ToggleIsometricView",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
                 {
                     "name": "",
                     "id": "667dbb8b-558f-4ca7-b045-f5965a714dc2",
-                    "path": "<Keyboard>/q",
+                    "path": "<Keyboard>/backquote",
                     "interactions": "",
                     "processors": "",
                     "groups": ";KeyboardMouse",
-                    "action": "ToggleOverheadView",
+                    "action": "ToggleIsometricView",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },


### PR DESCRIPTION
Bug:

on start of game, both the player movement script and the isometric move/rotate scripts were active. So when player moves, furniture moves. 

Bug Source:
- I forgot to rename the input action name to `ToggleIsometricView` in the New Input system section for both player and isometric view control map.
- Both player movement and the isometric view scripts were enabled at start.

Fix:
- Renamed both player and isometric control maps to `ToggleIsometricView`
- Disable isometric view script in `Start` so we always have it off. Then when switching we do the following:
  - To Isometric mode: turn off player movement and animation scripts. Turn on iso script
  - To build mode: turn off iso script, turn on player movement and animation scripts.